### PR TITLE
Switch to RFFT for Fourier transforms

### DIFF
--- a/Examples/1D_Landau_damping.py
+++ b/Examples/1D_Landau_damping.py
@@ -38,19 +38,17 @@ L = Lx * jnp.sign(nx) + Ly * jnp.sign(ny) + Lz * jnp.sign(nz)
 E_field_component = int(jnp.sign(ny) + 2 * jnp.sign(nz))
 
 # Fourier components of magnetic and electric fields.
-Fk_0 = jnp.zeros((6, Ny, Nx, Nz), dtype=jnp.complex128)
-Fk_0 = Fk_0.at[E_field_component, int((Ny-1)/2-ny), int((Nx-1)/2-nx), int((Nz-1)/2-nz)].set(dn * L / (4 * jnp.pi * n * Omega_cs[0]))
-Fk_0 = Fk_0.at[E_field_component, int((Ny-1)/2+ny), int((Nx-1)/2+nx), int((Nz-1)/2+nz)].set(dn * L / (4 * jnp.pi * n * Omega_cs[0]))
+Fk_0 = jnp.zeros((6, Ny, Nx//2+1, Nz), dtype=jnp.complex128)
+Fk_0 = Fk_0.at[E_field_component, ny, nx, nz].set(dn * L / (4 * jnp.pi * n * Omega_cs[0])) # TODO May be incorrect for nx = 0
 input_parameters["Fk_0"] = Fk_0
 
 # Hermite-Fourier components of electron and ion distribution functions.
 Ce0_mk, Ce0_0, Ce0_k = 0 + 1j * (1 / (2 * alpha_s[0] ** 3)) * dn, 1 / (alpha_s[0] ** 3) + 0 * 1j, 0 - 1j * (1 / (2 * alpha_s[0] ** 3)) * dn
 Ci0_0 = 1 / (alpha_s[3] ** 3) + 0 * 1j
-Ck_0 = jnp.zeros((2 * Nn * Nm * Np, Ny, Nx, Nz), dtype=jnp.complex128)
-Ck_0 = Ck_0.at[0, int((Ny-1)/2-ny), int((Nx-1)/2-nx), int((Nz-1)/2-nz)].set(Ce0_mk)
-Ck_0 = Ck_0.at[0, int((Ny-1)/2), int((Nx-1)/2), int((Nz-1)/2)].set(Ce0_0)
-Ck_0 = Ck_0.at[0, int((Ny-1)/2+ny), int((Nx-1)/2+nx), int((Nz-1)/2+nz)].set(Ce0_k)
-Ck_0 = Ck_0.at[Nn * Nm * Np, int((Ny-1)/2), int((Nx-1)/2), int((Nz-1)/2)].set(Ci0_0)
+Ck_0 = jnp.zeros((2 * Nn * Nm * Np, Ny, Nx//2+1, Nz), dtype=jnp.complex128)
+Ck_0 = Ck_0.at[0, 0, 0, 0].set(Ce0_0)
+Ck_0 = Ck_0.at[0, ny, nx, nz].set(Ce0_k) # TODO May be incorrect for nx = 0
+Ck_0 = Ck_0.at[Nn * Nm * Np, 0, 0, 0].set(Ci0_0)
 input_parameters["Ck_0"] = Ck_0
 
 # Simulate

--- a/Examples/1D_Landau_damping.py
+++ b/Examples/1D_Landau_damping.py
@@ -39,15 +39,14 @@ E_field_component = int(jnp.sign(ny) + 2 * jnp.sign(nz))
 
 # Fourier components of magnetic and electric fields.
 Fk_0 = jnp.zeros((6, Ny, Nx//2+1, Nz), dtype=jnp.complex128)
-Fk_0 = Fk_0.at[E_field_component, ny, nx, nz].set(dn * L / (4 * jnp.pi * n * Omega_cs[0])) # TODO May be incorrect for nx = 0
-input_parameters["Fk_0"] = Fk_0
+Fk_0 = Fk_0.at[E_field_component, ny, nx, nz].set(dn * L / (4 * jnp.pi * n * Omega_cs[0]))
 
 # Hermite-Fourier components of electron and ion distribution functions.
 Ce0_mk, Ce0_0, Ce0_k = 0 + 1j * (1 / (2 * alpha_s[0] ** 3)) * dn, 1 / (alpha_s[0] ** 3) + 0 * 1j, 0 - 1j * (1 / (2 * alpha_s[0] ** 3)) * dn
 Ci0_0 = 1 / (alpha_s[3] ** 3) + 0 * 1j
 Ck_0 = jnp.zeros((2 * Nn * Nm * Np, Ny, Nx//2+1, Nz), dtype=jnp.complex128)
 Ck_0 = Ck_0.at[0, 0, 0, 0].set(Ce0_0)
-Ck_0 = Ck_0.at[0, ny, nx, nz].set(Ce0_k) # TODO May be incorrect for nx = 0
+Ck_0 = Ck_0.at[0, ny, nx, nz].set(Ce0_k)
 Ck_0 = Ck_0.at[Nn * Nm * Np, 0, 0, 0].set(Ci0_0)
 input_parameters["Ck_0"] = Ck_0
 

--- a/Examples/1D_Landau_damping.py
+++ b/Examples/1D_Landau_damping.py
@@ -45,6 +45,8 @@ Fk_0 = Fk_0.at[E_field_component, ny, nx, nz].set(dn * L / (4 * jnp.pi * n * Ome
 Ce0_mk, Ce0_0, Ce0_k = 0 + 1j * (1 / (2 * alpha_s[0] ** 3)) * dn, 1 / (alpha_s[0] ** 3) + 0 * 1j, 0 - 1j * (1 / (2 * alpha_s[0] ** 3)) * dn
 Ci0_0 = 1 / (alpha_s[3] ** 3) + 0 * 1j
 Ck_0 = jnp.zeros((2 * Nn * Nm * Np, Ny, Nx//2+1, Nz), dtype=jnp.complex128)
+if nx == 0 and (ny != 0 or nz != 0):
+    Ck_0 = Ck_0.at[0, -ny, 0, -nz].set(Ce0_mk) # The negative nx, ny, nz index only exists if nx=0
 Ck_0 = Ck_0.at[0, 0, 0, 0].set(Ce0_0)
 Ck_0 = Ck_0.at[0, ny, nx, nz].set(Ce0_k)
 Ck_0 = Ck_0.at[Nn * Nm * Np, 0, 0, 0].set(Ci0_0)

--- a/Examples/1D_Landau_damping_dr_curve.py
+++ b/Examples/1D_Landau_damping_dr_curve.py
@@ -71,9 +71,11 @@ E_field_component = int(jnp.sign(ny) + 2 * jnp.sign(nz))
 # Initial condition: Hermite-Fourier components of electron and ion
 # distribution functions (background + small sinusoidal perturbation).
 # ---------------------------------------------------------------------------
-Ce0_0, Ce0_k = 1 / (alpha_s[0] ** 3) + 0 * 1j, 0 - 1j * (1 / (2 * alpha_s[0] ** 3)) * dn
+Ce0_mk, Ce0_0, Ce0_k = 0 + 1j * (1 / (2 * alpha_s[0] ** 3)) * dn, 1 / (alpha_s[0] ** 3) + 0 * 1j, 0 - 1j * (1 / (2 * alpha_s[0] ** 3)) * dn
 Ci0_0 = 1 / (alpha_s[3] ** 3) + 0 * 1j
 Ck_0 = jnp.zeros((2 * Nn * Nm * Np, Ny, Nx//2+1, Nz), dtype=jnp.complex128)
+if nx == 0 and (ny != 0 or nz != 0):
+    Ck_0 = Ck_0.at[0, -ny, 0, -nz].set(Ce0_mk) # The negative nx, ny, nz index only exists if nx=0
 Ck_0 = Ck_0.at[0, 0, 0, 0].set(Ce0_0)
 Ck_0 = Ck_0.at[0, ny, nx, nz].set(Ce0_k)
 Ck_0 = Ck_0.at[Nn * Nm * Np, 0, 0, 0].set(Ci0_0)
@@ -93,6 +95,8 @@ for j in jnp.arange(len(kx)):
     # Initialize Fourier components of the electromagnetic fields.
     Fk_0 = jnp.zeros((6, Ny, Nx//2+1, Nz), dtype=jnp.complex128)
     Fk_0 = Fk_0.at[E_field_component, ny, nx, nz].set(dn * Lx / (4 * jnp.pi * n * Omega_cs[0]))
+    if nx == 0 and (ny != 0 or nz != 0):
+        Fk_0 = Fk_0.at[E_field_component, -ny, -nx, -nz].set(dn * Lx / (4 * jnp.pi * n * Omega_cs[0]))
     input_parameters["Fk_0"] = Fk_0
 
     # Run the simulation (block until the JAX computation is complete).

--- a/Examples/1D_Landau_damping_dr_curve.py
+++ b/Examples/1D_Landau_damping_dr_curve.py
@@ -71,13 +71,12 @@ E_field_component = int(jnp.sign(ny) + 2 * jnp.sign(nz))
 # Initial condition: Hermite-Fourier components of electron and ion
 # distribution functions (background + small sinusoidal perturbation).
 # ---------------------------------------------------------------------------
-Ce0_mk, Ce0_0, Ce0_k = 0 + 1j * (1 / (2 * alpha_s[0] ** 3)) * dn, 1 / (alpha_s[0] ** 3) + 0 * 1j, 0 - 1j * (1 / (2 * alpha_s[0] ** 3)) * dn
+Ce0_0, Ce0_k = 1 / (alpha_s[0] ** 3) + 0 * 1j, 0 - 1j * (1 / (2 * alpha_s[0] ** 3)) * dn
 Ci0_0 = 1 / (alpha_s[3] ** 3) + 0 * 1j
-Ck_0 = jnp.zeros((2 * Nn * Nm * Np, Ny, Nx, Nz), dtype=jnp.complex128)
-Ck_0 = Ck_0.at[0, int((Ny-1)/2-ny), int((Nx-1)/2-nx), int((Nz-1)/2-nz)].set(Ce0_mk)
-Ck_0 = Ck_0.at[0, int((Ny-1)/2), int((Nx-1)/2), int((Nz-1)/2)].set(Ce0_0)
-Ck_0 = Ck_0.at[0, int((Ny-1)/2+ny), int((Nx-1)/2+nx), int((Nz-1)/2+nz)].set(Ce0_k)
-Ck_0 = Ck_0.at[Nn * Nm * Np, int((Ny-1)/2), int((Nx-1)/2), int((Nz-1)/2)].set(Ci0_0)
+Ck_0 = jnp.zeros((2 * Nn * Nm * Np, Ny, Nx//2+1, Nz), dtype=jnp.complex128)
+Ck_0 = Ck_0.at[0, 0, 0, 0].set(Ce0_0)
+Ck_0 = Ck_0.at[0, ny, nx, nz].set(Ce0_k)
+Ck_0 = Ck_0.at[Nn * Nm * Np, 0, 0, 0].set(Ci0_0)
 input_parameters["Ck_0"] = Ck_0
 
 # Target dimensionless wavenumbers to scan.
@@ -92,9 +91,8 @@ for j in jnp.arange(len(kx)):
     input_parameters["Lx"] = Lx
 
     # Initialize Fourier components of the electromagnetic fields.
-    Fk_0 = jnp.zeros((6, Ny, Nx, Nz), dtype=jnp.complex128)
-    Fk_0 = Fk_0.at[E_field_component, int((Ny-1)/2-ny), int((Nx-1)/2-nx), int((Nz-1)/2-nz)].set(dn * Lx / (4 * jnp.pi * n * Omega_cs[0]))
-    Fk_0 = Fk_0.at[E_field_component, int((Ny-1)/2+ny), int((Nx-1)/2+nx), int((Nz-1)/2+nz)].set(dn * Lx / (4 * jnp.pi * n * Omega_cs[0]))
+    Fk_0 = jnp.zeros((6, Ny, Nx//2+1, Nz), dtype=jnp.complex128)
+    Fk_0 = Fk_0.at[E_field_component, ny, nx, nz].set(dn * Lx / (4 * jnp.pi * n * Omega_cs[0]))
     input_parameters["Fk_0"] = Fk_0
 
     # Run the simulation (block until the JAX computation is complete).

--- a/Examples/1D_two_stream.py
+++ b/Examples/1D_two_stream.py
@@ -28,23 +28,18 @@ Nx = solver_parameters["Nx"]
 Nn = solver_parameters["Nn"]
 
 # Initialize distribution function as a two-stream instability
-indices = jnp.array([int((Nx-1)/2-nx), int((Nx-1)/2+nx)])
 values  = (dn1 + dn2) * Lx / (4 * jnp.pi * nx * Omega_cs[0])
-Fk_0    = jnp.zeros((6, 1, Nx, 1), dtype=jnp.complex128).at[0, 0, indices, 0].set(values)
+Fk_0    = jnp.zeros((6, 1, Nx//2+1, 1), dtype=jnp.complex128).at[0, 0, nx, 0].set(values)
 input_parameters["Fk_0"] = Fk_0
 
-C10     = jnp.array([
-        0 + 1j * (1 / (2 * alpha_s[0] ** 3)) * dn1,
-        1 / (alpha_s[0] ** 3) + 0 * 1j,
+C10     = jnp.array([1 / (alpha_s[0] ** 3) + 0 * 1j,
         0 - 1j * (1 / (2 * alpha_s[0] ** 3)) * dn1
 ])
-C20     = jnp.array([
-        0 + 1j * (1 / (2 * alpha_s[3] ** 3)) * dn2,
-        1 / (alpha_s[3] ** 3) + 0 * 1j,
+C20     = jnp.array([1 / (alpha_s[3] ** 3) + 0 * 1j,
         0 - 1j * (1 / (2 * alpha_s[3] ** 3)) * dn2
 ])
-indices = jnp.array([int((Nx-1)/2-nx), int((Nx-1)/2), int((Nx-1)/2+nx)])
-Ck_0    = jnp.zeros((2 * Nn, 1, Nx, 1), dtype=jnp.complex128)
+indices = jnp.array([0, nx])
+Ck_0    = jnp.zeros((2 * Nn, 1, Nx//2+1, 1), dtype=jnp.complex128)
 Ck_0    = Ck_0.at[0,  0, indices, 0].set(C10)
 Ck_0    = Ck_0.at[Nn, 0, indices, 0].set(C20)
 input_parameters["Ck_0"] = Ck_0

--- a/Examples/1D_two_stream_gr_curve.py
+++ b/Examples/1D_two_stream_gr_curve.py
@@ -55,22 +55,20 @@ nu = input_parameters["nu"]
 # ---------------------------------------------------------------------------
 
 C10     = jnp.array([
-        0 + 1j * (1 / (2 * alpha_s[0] ** 3)) * dn1,
         1 / (alpha_s[0] ** 3) + 0 * 1j,
         0 - 1j * (1 / (2 * alpha_s[0] ** 3)) * dn1
 ])
 C20     = jnp.array([
-        0 + 1j * (1 / (2 * alpha_s[3] ** 3)) * dn2,
         1 / (alpha_s[3] ** 3) + 0 * 1j,
         0 - 1j * (1 / (2 * alpha_s[3] ** 3)) * dn2
 ])
 
-# Indices corresponding to (-k, 0, +k) for the chosen Fourier mode in x.
-indices = jnp.array([int((Nx-1)/2-nx), int((Nx-1)/2), int((Nx-1)/2+nx)])
+# Indices corresponding to (0, k) for the chosen Fourier mode in x.
+indices = jnp.array([0, nx])
 
 # Ck_0 stores the Hermite-Fourier coefficients for each species.
-# Here Ns=2 and Nm=Nz=1 so the shape is (2*Nn, 1, Nx, 1).
-Ck_0    = jnp.zeros((2 * Nn, 1, Nx, 1), dtype=jnp.complex128)
+# Here Ns=2 and Nm=Nz=1 so the shape is (2*Nn, 1, Nx//2+1, 1).
+Ck_0    = jnp.zeros((2 * Nn, 1, Nx//2+1, 1), dtype=jnp.complex128)
 Ck_0    = Ck_0.at[0,  0, indices, 0].set(C10)
 Ck_0    = Ck_0.at[Nn, 0, indices, 0].set(C20)
 input_parameters["Ck_0"] = Ck_0
@@ -87,9 +85,8 @@ for j in jnp.arange(len(kx)):
     input_parameters["Lx"] = Lx
 
     # Initialize Fourier components of the electromagnetic fields.
-    indices = jnp.array([int((Nx-1)/2-nx), int((Nx-1)/2+nx)])
-    values  = (dn1 + dn2) * Lx / (4 * jnp.pi * nx * Omega_cs[0])
-    Fk_0    = jnp.zeros((6, 1, Nx, 1), dtype=jnp.complex128).at[0, 0, indices, 0].set(values)
+    value  = (dn1 + dn2) * Lx / (4 * jnp.pi * nx * Omega_cs[0])
+    Fk_0    = jnp.zeros((6, 1, Nx//2+1, 1), dtype=jnp.complex128).at[0, 0, nx, 0].set(value)
     input_parameters["Fk_0"] = Fk_0
 
     # Run the simulation (block until the JAX computation is complete).

--- a/Examples/2D_Orszag_Tang.py
+++ b/Examples/2D_Orszag_Tang.py
@@ -14,7 +14,7 @@ from jax import block_until_ready, config
 config.update("jax_enable_x64", True)
 import jax.numpy as jnp
 from spectrax import simulation, load_parameters, compute_C_nmp
-from jax.numpy.fft import fftn, fftshift
+from jax.numpy.fft import rfftn
 from orszag_tang_data_analysis import (
         plot_energy_timeseries, plot_relative_energy_error,
         plot_Jz_slice, animate_Jz
@@ -63,7 +63,7 @@ input_parameters["Ck_0"] = compute_C_nmp(Us_grid, alpha_s, u_s, Nn, Nm, Np, Ns)
 B_grid = B(X, Y, Z)  # shape (3, Ny, Nx, Nz)
 E_grid = E(X, Y, Z)  # shape (3, Ny, Nx, Nz)
 F_grid = jnp.concatenate((E_grid, B_grid), axis=0)  # shape (6, Ny, Nx, Nz)
-input_parameters["Fk_0"] = fftshift(fftn(F_grid, axes=(-3, -2, -1), norm="forward"), axes=(-3, -2, -1))  # shape (6, Ny, Nx, Nz)
+input_parameters["Fk_0"] = rfftn(F_grid, axes=(-1, -3, -2), norm="forward")  # shape (6, Ny, Nx//2+1, Nz)
 
 
 print('Starting simulation...')

--- a/Examples/orszag_tang_data_analysis.py
+++ b/Examples/orszag_tang_data_analysis.py
@@ -205,12 +205,11 @@ def _ifft_Ck_frame(Ck_frame: Array) -> Array:
     Inverse FFT (k->x) for one time frame.
 
     Matches the example:
-        C = ifftn(ifftshift(Ck, axes=(-3,-2,-1)), axes=(-3,-2,-1), norm="forward").real
+        C = ifftn(Ck, axes=(-1, -3, -2), norm="forward")
     """
     # Ensure complex dtype
     Ck_frame = np.asarray(Ck_frame)
-    shifted = np.fft.ifftshift(Ck_frame, axes=(-3, -2, -1))
-    C_frame = np.fft.ifftn(shifted, axes=(-3, -2, -1), norm="forward").real
+    C_frame = np.fft.irfftn(Ck_frame, axes=(-1, -3, -2), norm="forward")
     return C_frame
 
 

--- a/Examples/orszag_tang_data_analysis.py
+++ b/Examples/orszag_tang_data_analysis.py
@@ -200,7 +200,7 @@ def plot_relative_energy_error(
     return ax
 
 
-def _ifft_Ck_frame(Ck_frame: Array) -> Array:
+def _ifft_Ck_frame(Ck_frame: Array, Nx, Ny, Nz) -> Array:
     """
     Inverse FFT (k->x) for one time frame.
 
@@ -209,7 +209,7 @@ def _ifft_Ck_frame(Ck_frame: Array) -> Array:
     """
     # Ensure complex dtype
     Ck_frame = np.asarray(Ck_frame)
-    C_frame = np.fft.irfftn(Ck_frame, axes=(-1, -3, -2), norm="forward")
+    C_frame = np.fft.irfftn(Ck_frame, s=(Nz, Ny, Nx), axes=(-1, -3, -2), norm="forward")
     return C_frame
 
 
@@ -277,6 +277,10 @@ def compute_Jz_slice(
     t = np.asarray(output["time"])
     Ck = np.asarray(output["Ck"])
 
+    Nx = int(solver_parameters["Nx"])
+    Ny = int(solver_parameters["Ny"])
+    Nz = int(solver_parameters["Nz"])
+
     if index is None and t_query is None:
         index = int(t.shape[0] - 1)
     elif index is None:
@@ -284,7 +288,7 @@ def compute_Jz_slice(
     else:
         index = int(index)
 
-    C_frame = _ifft_Ck_frame(Ck[index])
+    C_frame = _ifft_Ck_frame(Ck[index], Nx, Ny, Nz)
     Jz = _compute_Jz_from_C_frame(C_frame, input_parameters, solver_parameters)
     return Jz, float(t[index]), index
 
@@ -379,6 +383,10 @@ def animate_Jz(
     stop = _frame_stop_index(t, tmax)
     nframes = stop
 
+    Nx = int(solver_parameters["Nx"])
+    Ny = int(solver_parameters["Ny"])
+    Nz = int(solver_parameters["Nz"])
+
     Lx = float(input_parameters["Lx"])
     Ly = float(input_parameters["Ly"])
 
@@ -392,7 +400,7 @@ def animate_Jz(
     if precompute:
         Jz_list = []
         for i in range(nframes):
-            C_frame = _ifft_Ck_frame(Ck[i])
+            C_frame = _ifft_Ck_frame(Ck[i], Nx, Ny, Nz)
             Jz_i = _compute_Jz_from_C_frame(C_frame, input_parameters, solver_parameters)
             Jz_list.append(Jz_i)
         Jz_series = np.stack(Jz_list, axis=0)  # (t, Nx, Ny)
@@ -410,7 +418,7 @@ def animate_Jz(
     if precompute:
         J0 = Jz_series[0]
     else:
-        C0 = _ifft_Ck_frame(Ck[0])
+        C0 = _ifft_Ck_frame(Ck[0], Nx, Ny, Nz)
         J0 = _compute_Jz_from_C_frame(C0, input_parameters, solver_parameters)
 
     im = ax.imshow(
@@ -432,7 +440,7 @@ def animate_Jz(
     def _get_frame(i: int) -> Array:
         if precompute:
             return Jz_series[i]
-        C_frame = _ifft_Ck_frame(Ck[i])
+        C_frame = _ifft_Ck_frame(Ck[i], Nx, Ny, Nz)
         return _compute_Jz_from_C_frame(C_frame, input_parameters, solver_parameters)
 
     def update(i: int):

--- a/TODO
+++ b/TODO
@@ -1,0 +1,1 @@
+- Try reordering spatial axes to make x last

--- a/TODO
+++ b/TODO
@@ -1,1 +1,0 @@
-- Pass Nx, Ny, Nz into inverse_transform

--- a/TODO
+++ b/TODO
@@ -1,3 +1,1 @@
-- Try reordering spatial axes to make x last
-- Get all examples working
 - Pass Nx, Ny, Nz into diagnostics so we can handle even values, also possibly to inverse_transform

--- a/TODO
+++ b/TODO
@@ -1,1 +1,1 @@
-- Pass Nx, Ny, Nz into diagnostics so we can handle even values, also possibly to inverse_transform
+- Pass Nx, Ny, Nz into inverse_transform

--- a/TODO
+++ b/TODO
@@ -1,1 +1,3 @@
 - Try reordering spatial axes to make x last
+- Get all examples working
+- Pass Nx, Ny, Nz into diagnostics so we can handle even values, also possibly to inverse_transform

--- a/spectrax/_diagnostics.py
+++ b/spectrax/_diagnostics.py
@@ -117,7 +117,6 @@ def diagnostics(output: dict) -> None:
 
     Ns = _infer_Ns(output)
 
-    Nx = output["Nx"] # TODO why not just take all of these? And replace Nx_kept with Nx//2+1 where it's used
     # Infer spatial grid sizes from shapes.
     Ny = int(Fk.shape[-3])
     Nx_kept = int(Fk.shape[-2])

--- a/spectrax/_diagnostics.py
+++ b/spectrax/_diagnostics.py
@@ -117,6 +117,7 @@ def diagnostics(output: dict) -> None:
 
     Ns = _infer_Ns(output)
 
+    Nx = output["Nx"] # TODO why not just take all of these? And replace Nx_kept with Nx//2+1 where it's used
     # Infer spatial grid sizes from shapes.
     Ny = int(Fk.shape[-3])
     Nx_kept = int(Fk.shape[-2])
@@ -208,11 +209,7 @@ def diagnostics(output: dict) -> None:
     # Field energy
     rfft_weights = jnp.full(Nx_kept, 2.0)
     rfft_weights = rfft_weights.at[0].set(1.0)
-    """
-    TODO only applicable if Nx is even, but we don't have Nx in diagnostics right now
-    if Nx % 2 == 0:
-        rfft_weights = rfft_weights.at[-1].set(1.0)
-    """
+    rfft_weights = rfft_weights.at[-1].set(1.0)
     weight_grid = rfft_weights.reshape(1, 1, -1, 1)
     EM_energy = 0.5 * jnp.sum((jnp.abs(Fk) ** 2) * weight_grid, axis=(-4, -3, -2, -1)) * Omega_cs[0] ** 2
 

--- a/spectrax/_diagnostics.py
+++ b/spectrax/_diagnostics.py
@@ -79,8 +79,8 @@ def diagnostics(output: dict) -> None:
 
         - ``alpha_s``: array of shape ``(3*Ns,)`` (thermal scales per species)
         - ``u_s``: array of shape ``(3*Ns,)`` (drift velocities per species)
-        - ``Ck``: Hermite-Fourier coefficients of shape ``(Nt, Ns*Hs, Ny, Nx, Nz)``
-        - ``Fk``: field Fourier coefficients of shape ``(Nt, 6, Ny, Nx, Nz)``
+        - ``Ck``: Hermite-Fourier coefficients of shape ``(Nt, Ns*Hs, Ny, Nx//2+1, Nz)``
+        - ``Fk``: field Fourier coefficients of shape ``(Nt, 6, Ny, Nx//2+1, Nz)``
         - ``Omega_cs``: array of shape ``(Ns,)`` (cyclotron frequencies)
         - ``Lx``: domain length in x (used for ``k_norm``)
 
@@ -118,17 +118,9 @@ def diagnostics(output: dict) -> None:
     Ns = _infer_Ns(output)
 
     # Infer spatial grid sizes from shapes.
-    # Arrays are stored in fftshift ordering throughout the solver.
     Ny = int(Fk.shape[-3])
-    Nx = int(Fk.shape[-2])
+    Nx_kept = int(Fk.shape[-2])
     Nz = int(Fk.shape[-1])
-
-    # k=0 mode indices for fftshifted arrays.
-    # - for odd N:  N//2 == (N-1)//2
-    # - for even N: N//2 correctly points to the centered zero-frequency bin
-    half_ny = Ny // 2
-    half_nx = Nx // 2
-    half_nz = Nz // 2
 
     # Basic sanity
     if alpha_s.size != 3 * Ns:
@@ -163,8 +155,8 @@ def diagnostics(output: dict) -> None:
     k_norm = jnp.sqrt(2.0) * jnp.pi * alpha_s[0] / Lx
 
     # Reshape Ck into species blocks along Hermite axis:
-    # (Nt, Htot, Ny, Nx, Nz) -> (Nt, Ns, Hs, Ny, Nx, Nz)
-    Ck_rs = Ck.reshape(Ck.shape[0], Ns, Hs, Ny, Nx, Nz)
+    # (Nt, Htot, Ny, Nx//2+1, Nz) -> (Nt, Ns, Hs, Ny, Nx//2+1, Nz)
+    Ck_rs = Ck.reshape(Ck.shape[0], Ns, Hs, Ny, Nx_kept, Nz)
 
     def _take_mode(offset: Any) -> jnp.ndarray:
         """Gather a Hermite coefficient at a given per-species flattened index.
@@ -182,7 +174,7 @@ def diagnostics(output: dict) -> None:
         offset = jnp.asarray(offset, dtype=jnp.int32)
         off_clip = jnp.clip(offset, 0, Hs - 1)
         gathered = jnp.take(Ck_rs, off_clip, axis=2, mode="clip")  # (Nt, Ns, Ny, Nx, Nz)
-        k0 = gathered[:, :, half_ny, half_nx, half_nz]              # (Nt, Ns)
+        k0 = gathered[:, :, 0, 0, 0]              # (Nt, Ns)
         mask = (offset >= 0) & (offset < Hs)
         return k0 * mask.astype(k0.dtype)
 
@@ -214,7 +206,15 @@ def diagnostics(output: dict) -> None:
     kinetic_energy_species = pref[None, :] * (term0[None, :] * C000 + term1 + term2)  # (Nt, Ns)
     kinetic_energy = jnp.sum(kinetic_energy_species, axis=1)  # (Nt,)
     # Field energy
-    EM_energy = 0.5 * jnp.sum(jnp.abs(Fk) ** 2, axis=(-4, -3, -2, -1)) * Omega_cs[0] ** 2  # (Nt,)
+    rfft_weights = jnp.full(Nx_kept, 2.0)
+    rfft_weights = rfft_weights.at[0].set(1.0)
+    """
+    TODO only applicable if Nx is even, but we don't have Nx in diagnostics right now
+    if Nx % 2 == 0:
+        rfft_weights = rfft_weights.at[-1].set(1.0)
+    """
+    weight_grid = rfft_weights.reshape(1, 1, -1, 1)
+    EM_energy = 0.5 * jnp.sum((jnp.abs(Fk) ** 2) * weight_grid, axis=(-4, -3, -2, -1)) * Omega_cs[0] ** 2
 
     total_energy = kinetic_energy + EM_energy
 

--- a/spectrax/_diagnostics.py
+++ b/spectrax/_diagnostics.py
@@ -158,36 +158,28 @@ def diagnostics(output: dict) -> None:
     # (Nt, Htot, Ny, Nx//2+1, Nz) -> (Nt, Ns, Hs, Ny, Nx//2+1, Nz)
     Ck_rs = Ck.reshape(Ck.shape[0], Ns, Hs, Ny, Nx_kept, Nz)
 
-    def _take_mode(offset: Any) -> jnp.ndarray:
-        """Gather a Hermite coefficient at a given per-species flattened index.
-
-        This helper is used to safely extract low-order Hermite moments such as
-        ``C000`` and ``C100`` even when the Hermite basis is truncated so that
-        some offsets fall out of range.
-
-        Returns
-        -------
-        jnp.ndarray
-            Array of shape ``(Nt, Ns)`` giving the coefficient evaluated at the
-            k=0 Fourier mode.
-        """
+    def _take_mode(n: int, m: int, p: int) -> jnp.ndarray:
+        """Gather a Hermite coefficient using explicit (n, m, p) indices."""
+        # Flatten the index based on Nn, Nm, Np
+        offset = n + Nn * m + Nn * Nm * p
         offset = jnp.asarray(offset, dtype=jnp.int32)
         off_clip = jnp.clip(offset, 0, Hs - 1)
         gathered = jnp.take(Ck_rs, off_clip, axis=2, mode="clip")  # (Nt, Ns, Ny, Nx, Nz)
         k0 = gathered[:, :, 0, 0, 0]              # (Nt, Ns)
-        mask = (offset >= 0) & (offset < Hs)
+        
+        # Strictly mask out modes that fall outside the allocated resolution
+        mask = (n < Nn) & (m < Nm) & (p < Np) & (n >= 0) & (m >= 0) & (p >= 0)
         return k0 * mask.astype(k0.dtype)
 
-    # Low-order Hermite moments in flattened (n,m,p) indexing:
-    # idx = n + Nn*m + Nn*Nm*p
-    C000 = _take_mode(0)
-    C100 = _take_mode(1)
-    C010 = _take_mode(Nn)
-    C001 = _take_mode(Nn * Nm)
+    # Low-order Hermite moments
+    C000 = _take_mode(0, 0, 0)
+    C100 = _take_mode(1, 0, 0)
+    C010 = _take_mode(0, 1, 0)
+    C001 = _take_mode(0, 0, 1)
 
-    C200 = _take_mode(2)
-    C020 = _take_mode(2 * Nn)
-    C002 = _take_mode(2 * Nn * Nm)
+    C200 = _take_mode(2, 0, 0)
+    C020 = _take_mode(0, 2, 0)
+    C002 = _take_mode(0, 0, 2)
 
     # Species parameters
     alpha = alpha_s.reshape(Ns, 3)

--- a/spectrax/_initialization.py
+++ b/spectrax/_initialization.py
@@ -113,7 +113,7 @@ def initialize_simulation_parameters(user_parameters={}, Nx=33, Ny=1, Nz=1, Nn=5
     ky_simulation = jnp.fft.fftfreq(Ny) * Ny * 2 * jnp.pi
     kz_simulation = jnp.fft.fftfreq(Nz) * Nz * 2 * jnp.pi
 
-    kx_grid, ky_grid, kz_grid = jnp.meshgrid(kx_simulation, ky_simulation, kz_simulation, indexing='xy')
+    ky_grid, kx_grid, kz_grid = jnp.meshgrid(ky_simulation, kx_simulation, kz_simulation, indexing='ij')
     k2_grid = kx_grid**2 + ky_grid**2 + kz_grid**2
     nabla = jnp.array([kx_grid / Lx, ky_grid / Ly, kz_grid / Lz])
 

--- a/spectrax/_initialization.py
+++ b/spectrax/_initialization.py
@@ -72,24 +72,19 @@ def initialize_simulation_parameters(user_parameters={}, Nx=33, Ny=1, Nz=1, Nn=5
     }
     
     # Initialize distribution function as a two-stream instability
-    indices = jnp.array([int((Nx-1)/2-default_parameters["nx"]), int((Nx-1)/2+default_parameters["nx"])])
     dn1     = default_parameters["dn1"]
     dn2     = default_parameters["dn2"]
     alpha_e = default_parameters["alpha_e"]
     values  = (dn1 + dn2) * default_parameters["Lx"] / (4 * jnp.pi * default_parameters["nx"] * default_parameters["Omega_cs"](default_parameters)[0])
-    Fk_0    = jnp.zeros((6, 1, Nx, 1), dtype=jnp.complex128).at[0, 0, indices, 0].set(values)
-    C10     = jnp.array([
-            0 + 1j * (1 / (2 * alpha_e[0] ** 3)) * dn1,
-            1 / (alpha_e[0] ** 3) + 0 * 1j,
+    Fk_0    = jnp.zeros((6, 1, Nx//2+1, 1), dtype=jnp.complex128).at[0, 0, default_parameters["nx"], 0].set(values)
+    C10     = jnp.array([1 / (alpha_e[0] ** 3) + 0 * 1j,
             0 - 1j * (1 / (2 * alpha_e[0] ** 3)) * dn1
     ])
-    C20     = jnp.array([
-            0 + 1j * (1 / (2 * alpha_e[0] ** 3)) * dn2,
-            1 / (alpha_e[0] ** 3) + 0 * 1j,
+    C20     = jnp.array([1 / (alpha_e[0] ** 3) + 0 * 1j,
             0 - 1j * (1 / (2 * alpha_e[0] ** 3)) * dn2
     ])
-    indices = jnp.array([int((Nx-1)/2-default_parameters["nx"]), int((Nx-1)/2), int((Nx-1)/2+default_parameters["nx"])])
-    Ck_0    = jnp.zeros((2 * Nn, 1, Nx, 1), dtype=jnp.complex128)
+    indices = jnp.array([0, default_parameters["nx"]])
+    Ck_0    = jnp.zeros((2 * Nn, 1, Nx//2+1, 1), dtype=jnp.complex128)
     Ck_0    = Ck_0.at[0,  0, indices, 0].set(C10)
     Ck_0    = Ck_0.at[Nn, 0, indices, 0].set(C20)
     
@@ -111,9 +106,13 @@ def initialize_simulation_parameters(user_parameters={}, Nx=33, Ny=1, Nz=1, Nn=5
             parameters[key] = value(parameters)
         if isinstance(value, list):
             parameters[key] = jnp.array(value)
-    kx_simulation = (jnp.arange(-Nx//2, Nx//2) + 1) * 2 * jnp.pi
-    ky_simulation = (jnp.arange(-Ny//2, Ny//2) + 1) * 2 * jnp.pi
-    kz_simulation = (jnp.arange(-Nz//2, Nz//2) + 1) * 2 * jnp.pi  
+
+    # Real-valued fft leaves only the positive-k elements on the last axis given.
+    # We choose the x-axis since this gets us the savings in 1D as well as 2D/3D.
+    kx_simulation = jnp.fft.rfftfreq(Nx) * Nx * 2 * jnp.pi
+    ky_simulation = jnp.fft.fftfreq(Ny) * Ny * 2 * jnp.pi
+    kz_simulation = jnp.fft.fftfreq(Nz) * Nz * 2 * jnp.pi
+
     kx_grid, ky_grid, kz_grid = jnp.meshgrid(kx_simulation, ky_simulation, kz_simulation, indexing='xy')
     k2_grid = kx_grid**2 + ky_grid**2 + kz_grid**2
     nabla = jnp.array([kx_grid / Lx, ky_grid / Ly, kz_grid / Lz])

--- a/spectrax/_initialize_maxwellian.py
+++ b/spectrax/_initialize_maxwellian.py
@@ -39,9 +39,9 @@ def compute_C_nmp(Us_grid, alpha_s, u_s, Nn, Nm, Np, Ns):
         corresponding to the Maxwellian evaluated on the supplied grid.
     """
     
-    U_x = Us_grid[:, 0, None, None, None, :, :, :] # shape (Ns, 1, 1, 1, Ny, Nx//2+1, Nz)
-    U_y = Us_grid[:, 1, None, None, None, :, :, :] # shape (Ns, 1, 1, 1, Ny, Nx//2+1, Nz)
-    U_z = Us_grid[:, 2, None, None, None, :, :, :] # shape (Ns, 1, 1, 1, Ny, Nx//2+1, Nz)
+    U_x = Us_grid[:, 0, None, None, None, :, :, :] # shape (Ns, 1, 1, 1, Ny, Nx, Nz)
+    U_y = Us_grid[:, 1, None, None, None, :, :, :] # shape (Ns, 1, 1, 1, Ny, Nx, Nz)
+    U_z = Us_grid[:, 2, None, None, None, :, :, :] # shape (Ns, 1, 1, 1, Ny, Nx, Nz)
 
     alpha = jnp.array(alpha_s).reshape(Ns, 3)
     alpha_x = alpha[:, 0, None, None, None, None, None, None] # shape (Ns, 1, 1, 1, 1, 1, 1)

--- a/spectrax/_initialize_maxwellian.py
+++ b/spectrax/_initialize_maxwellian.py
@@ -4,7 +4,7 @@ import jax
 jax.config.update("jax_enable_x64", True)
 import jax.numpy as jnp
 from jax import jit
-from jax.numpy.fft import fftn, fftshift
+from jax.numpy.fft import rfftn
 from jax.scipy.special import factorial
 from functools import partial
 
@@ -35,13 +35,13 @@ def compute_C_nmp(Us_grid, alpha_s, u_s, Nn, Nm, Np, Ns):
     Returns
     -------
     jnp.ndarray
-        Complex Hermite-Fourier coefficients with shape `(Ns, Np, Nm, Nn, Ny, Nx, Nz)`
+        Complex Hermite-Fourier coefficients with shape `(Ns, Np, Nm, Nn, Ny, Nx//2+1, Nz)`
         corresponding to the Maxwellian evaluated on the supplied grid.
     """
     
-    U_x = Us_grid[:, 0, None, None, None, :, :, :] # shape (Ns, 1, 1, 1, Ny, Nx, Nz)
-    U_y = Us_grid[:, 1, None, None, None, :, :, :] # shape (Ns, 1, 1, 1, Ny, Nx, Nz)
-    U_z = Us_grid[:, 2, None, None, None, :, :, :] # shape (Ns, 1, 1, 1, Ny, Nx, Nz)
+    U_x = Us_grid[:, 0, None, None, None, :, :, :] # shape (Ns, 1, 1, 1, Ny, Nx//2+1, Nz)
+    U_y = Us_grid[:, 1, None, None, None, :, :, :] # shape (Ns, 1, 1, 1, Ny, Nx//2+1, Nz)
+    U_z = Us_grid[:, 2, None, None, None, :, :, :] # shape (Ns, 1, 1, 1, Ny, Nx//2+1, Nz)
 
     alpha = jnp.array(alpha_s).reshape(Ns, 3)
     alpha_x = alpha[:, 0, None, None, None, None, None, None] # shape (Ns, 1, 1, 1, 1, 1, 1)
@@ -61,6 +61,6 @@ def compute_C_nmp(Us_grid, alpha_s, u_s, Nn, Nm, Np, Ns):
         * (1 / (alpha_x ** (n + 1) * alpha_y ** (m + 1) * alpha_z ** (p + 1)))
         * (U_x - u_x) ** n * (U_y - u_y) ** m * (U_z - u_z) ** p)
     
-    Ck_0 = fftshift(fftn(C, axes=(-3, -2, -1), norm="forward"), axes=(-3, -2, -1))  # shape (Ns, Np, Nm, Nn, Ny, Nx, Nz)
+    Ck_0 = rfftn(C, axes=(-1, -3, -2), norm="forward")  # shape (Ns, Np, Nm, Nn, Ny, Nx//2+1, Nz)
   
     return Ck_0

--- a/spectrax/_inverse_transform.py
+++ b/spectrax/_inverse_transform.py
@@ -94,8 +94,8 @@ def generate_Hermite_term(C, Herm_x, Herm_y, Herm_z, Nn, Nm, Np, xi_x, xi_y, xi_
     # -> f:    (Nt, Ny, Nx, Nz, Nvy, Nvx, Nvz)
     return jnp.tensordot(C, basis, axes=([1], [0])) * gauss[None, None, None, None, :, :, :]
 
-@partial(jit, static_argnames=['Nn', 'Nm', 'Np'])
-def inverse_HF_transform(Ck, Nn, Nm, Np, xi_x, xi_y, xi_z):
+@partial(jit, static_argnames=['Nn', 'Nm', 'Np', 'Nx', 'Ny', 'Nz'])
+def inverse_HF_transform(Ck, Nn, Nm, Np, Nx, Ny, Nz, xi_x, xi_y, xi_z):
     """Reconstruct ``f(x, v)`` from Hermite–Fourier coefficients.
 
     Parameters
@@ -105,6 +105,8 @@ def inverse_HF_transform(Ck, Nn, Nm, Np, xi_x, xi_y, xi_z):
         The inverse FFT is applied along the last three axes.
     Nn, Nm, Np : int
         Number of Hermite modes retained along each velocity-space axis.
+    Nx, Ny, Nz : int
+        Number of Fourier modes retained along each configuration-space axis.
     xi_x, xi_y, xi_z : jnp.ndarray
         Normalized velocity-space coordinates (typically ``(v - u)/alpha``) used
         to evaluate Hermite polynomials and the Gaussian weight.
@@ -114,7 +116,7 @@ def inverse_HF_transform(Ck, Nn, Nm, Np, xi_x, xi_y, xi_z):
     jnp.ndarray
         The reconstructed distribution function evaluated on ``(t, x, y, z, xi_x, xi_y, xi_z)``.
     """
-    C = irfftn(Ck, axes=(-1, -3, -2))
+    C = irfftn(Ck, s=(Nz, Ny, Nx), axes=(-1, -3, -2))
 
     # Precompute Hermite functions up to desired order
     Herm_x = generate_Hermite_basis(Nn, xi_x)  # (Nn, Nvy, Nvx, Nvz)

--- a/spectrax/_inverse_transform.py
+++ b/spectrax/_inverse_transform.py
@@ -8,7 +8,7 @@ Hermite–Fourier coefficients. The implementation is written for JAX and uses
 import jax
 jax.config.update("jax_enable_x64", True)
 import jax.numpy as jnp
-from jax.numpy.fft import ifftn, ifftshift
+from jax.numpy.fft import irfftn
 from jax.scipy.special import factorial
 from orthax.hermite import hermval
 from jax import jit, vmap
@@ -114,7 +114,7 @@ def inverse_HF_transform(Ck, Nn, Nm, Np, xi_x, xi_y, xi_z):
     jnp.ndarray
         The reconstructed distribution function evaluated on ``(t, x, y, z, xi_x, xi_y, xi_z)``.
     """
-    C = ifftn(ifftshift(Ck, axes=(-3, -2, -1)), axes=(-3, -2, -1)).real
+    C = irfftn(Ck, axes=(-1, -3, -2))
 
     # Precompute Hermite functions up to desired order
     Herm_x = generate_Hermite_basis(Nn, xi_x)  # (Nn, Nvy, Nvx, Nvz)

--- a/spectrax/_model.py
+++ b/spectrax/_model.py
@@ -25,7 +25,7 @@ def plasma_current(qs, alpha_s, u_s, Ck, Nn, Nm, Np, Ns):
         Velocity scaling factors for each species.
     u_s : jnp.ndarray, shape (3 * Ns,)
         Velocity shift for each species.
-    Ck : jnp.ndarray, shape (Ns * Np * Nm * Nn, Ny, Nx, Nz)
+    Ck : jnp.ndarray, shape (Ns * Np * Nm * Nn, Ny, Nx//2+1, Nz)
         Hermite-Fourier coefficients for all species stacked along the first axis.
     Nn, Nm, Np : int
         Number of Hermite modes in x, y, and z respectively.
@@ -37,7 +37,7 @@ def plasma_current(qs, alpha_s, u_s, Ck, Nn, Nm, Np, Ns):
     jnp.ndarray, shape (3, Ny, Nx, Nz)
         The total Ampère-Maxwell current components `(Jx, Jy, Jz)`.
     """
-    # Reshape Ck into structured Hermite-Fourier coefficients: (Ns, Np, Nm, Nn, Ny, Nx, Nz)
+    # Reshape Ck into structured Hermite-Fourier coefficients: (Ns, Np, Nm, Nn, Ny, Nx//2+1, Nz)
     Ck = Ck.reshape(Ns, Np, Nm, Nn, *Ck.shape[-3:])
     
     # Reshape alpha and velocity
@@ -45,7 +45,7 @@ def plasma_current(qs, alpha_s, u_s, Ck, Nn, Nm, Np, Ns):
     u = u_s.reshape(Ns, 3)
 
     # Grab the modes we need (0,1,1,1) for jx, jy, jz contributions
-    C0 = Ck[:, 0, 0, 0]  # shape: (Ns, Ny, Nx, Nz)
+    C0 = Ck[:, 0, 0, 0]  # shape: (Ns, Ny, Nx//2+1, Nz)
     C100 = Ck[:, 0, 0, 1] if Nn > 1 else jnp.zeros_like(C0)
     C010 = Ck[:, 0, 1, 0] if Nm > 1 else jnp.zeros_like(C0)
     C001 = Ck[:, 1, 0, 0] if Np > 1 else jnp.zeros_like(C0)
@@ -65,10 +65,10 @@ def plasma_current(qs, alpha_s, u_s, Ck, Nn, Nm, Np, Ns):
                        u1[:, None, None, None] * C0,
                        u2[:, None, None, None] * C0], axis=0)
 
-    # Final current per species: shape (3, Ns, Ny, Nx, Nz)
+    # Final current per species: shape (3, Ns, Ny, Nx//2+1, Nz)
     J_species = (term1 + term2) * pre[None, :, None, None, None]
 
-    # Sum over species → shape: (3, Ny, Nx, Nz)
+    # Sum over species → shape: (3, Ny, Nx//2+1, Nz)
     return jnp.sum(J_species, axis=1)
 
 def _pad_hermite_axes(Ck):
@@ -142,13 +142,12 @@ def Hermite_Fourier_system(Ck, C, F, kx_grid, ky_grid, kz_grid, k2_grid, col,
     Returns
     -------
     jnp.ndarray
-        Time derivative `dCk/dt` with shape `(Ns, Np, Nm, Nn, Ny, Nx, Nz)`.
+        Time derivative `dCk/dt` with shape `(Ns, Np, Nm, Nn, Ny, Nx//2+1, Nz)`.
     """
 
     Ck = Ck.reshape(Ns, Np, Nm, Nn, *Ck.shape[-3:])
     C = C.reshape(Ns, Np, Nm, Nn, *C.shape[-3:])
     F = F[:, None, None, None, None, :, :, :]  # (6,1,1,1,Nx,Ny,Nz) for broadcasting  
-    Ny, Nx, Nz = Ck.shape[-3], Ck.shape[-2], Ck.shape[-1]
     
     # Define u, alpha, charge, and gyrofrequency depending on species.
     alpha = alpha_s.reshape(Ns, 3)
@@ -203,10 +202,10 @@ def Hermite_Fourier_system(Ck, C, F, kx_grid, ky_grid, kz_grid, k2_grid, col,
         sqrt_p_minus / jnp.sqrt(2) * shift_multi(Ck, dn=0, dm=0, dp=-1) +
         (u2 / a2) * Ck
     ) + q * Omega_c * (
-        jnp.fft.fftshift(jnp.fft.fftn((sqrt_n_minus * jnp.sqrt(2) / a0) * F[0] * shift_multi(C, dn=-1, dm=0, dp=0) +
+        jnp.fft.rfftn((sqrt_n_minus * jnp.sqrt(2) / a0) * F[0] * shift_multi(C, dn=-1, dm=0, dp=0) +
                       (sqrt_m_minus * jnp.sqrt(2) / a1) * F[1] * shift_multi(C, dn=0, dm=-1, dp=0) + 
                       (sqrt_p_minus * jnp.sqrt(2) / a2) * F[2] * shift_multi(C, dn=0, dm=0, dp=-1) +
-                      F[3] * C_aux_x + F[4] * C_aux_y + F[5] * C_aux_z, axes=(-3, -2, -1), norm="forward"), axes=(-3, -2, -1)) * mask23
+                      F[3] * C_aux_x + F[4] * C_aux_y + F[5] * C_aux_z, axes=(-1, -3, -2), norm="forward") * mask23
     ) + Col + Diff)
     
     return dCk_s_dt

--- a/spectrax/_plot.py
+++ b/spectrax/_plot.py
@@ -67,7 +67,7 @@ def plot(output):
     i=0
     vx = jnp.linspace(-4 * alpha_s[0], 4 * alpha_s[0], 201)
     Vx, Vy, Vz = jnp.meshgrid(vx, jnp.array([0.]), jnp.array([0.]), indexing='xy')
-    f1 = inverse_HF_transform(Ck[:, (i*Nn*Nm*Np):(i+1)*Nn*Nm*Np, ...], Nn, Nm, Np, 
+    f1 = inverse_HF_transform(Ck[:, (i*Nn*Nm*Np):(i+1)*Nn*Nm*Np, ...], Nn, Nm, Np, int(Nx), int(Ny), int(Nz),
                                   (Vx - u_s[3*i]) / alpha_s[3*i], 
                                   (Vy - u_s[3*i+1]) / alpha_s[3*i+1], 
                                   (Vz - u_s[3*i+2]) / alpha_s[3*i+2])
@@ -84,7 +84,7 @@ def plot(output):
     i=1
     vx = jnp.linspace(-4 * alpha_s[0], 4 * alpha_s[0], 201)
     Vx, Vy, Vz = jnp.meshgrid(vx, jnp.array([0.]), jnp.array([0.]), indexing='xy')
-    f2 = inverse_HF_transform(Ck[:, (i*Nn*Nm*Np):(i+1)*Nn*Nm*Np, ...], Nn, Nm, Np, 
+    f2 = inverse_HF_transform(Ck[:, (i*Nn*Nm*Np):(i+1)*Nn*Nm*Np, ...], Nn, Nm, Np, int(Nx), int(Ny), int(Nz),
                                   (Vx - u_s[3*i]) / alpha_s[3*i], 
                                   (Vy - u_s[3*i+1]) / alpha_s[3*i+1], 
                                   (Vz - u_s[3*i+2]) / alpha_s[3*i+2])

--- a/spectrax/_plot.py
+++ b/spectrax/_plot.py
@@ -54,12 +54,12 @@ def plot(output):
     axes[1, 0].set(xlabel=r"Time ($\omega_{pe}^{-1}$)", ylabel="Relative Energy Error", yscale="log")#, ylim=[1e-5, None])
     
     # Plot electron density fluctuation vs t.
-    dnk1 = jnp.abs(output["dCk"][:, 0, int((Ny-1) / 2) + ny, int((Nx-1) / 2) + nx, int((Nz-1) / 2) + nz].imag) * alpha_s[0] * alpha_s[1] * alpha_s[2]
+    dnk1 = jnp.abs(output["dCk"][:, 0, ny, nx, nz].imag) * alpha_s[0] * alpha_s[1] * alpha_s[2]
     axes[1, 1].plot(time, dnk1, label=r'$|\delta n^{S1}_{k}|$', linestyle='-', linewidth=2.0)
     axes[1, 1].set(title='Species 1 density fluctuation', ylabel=r'$log(|\delta n^{s1}_{k}|)$', xlabel=r'$t\omega_{pe}$', yscale="log")#, ylim=[1e-20, None])
     
     # Plot ion density fluctuation vs t.
-    dnk2 = jnp.abs(output["dCk"][:, Nn * Nm * Np, int((Ny-1) / 2) + ny, int((Nx-1) / 2) + nx, int((Nz-1) / 2) + nz].imag) * alpha_s[3] * alpha_s[4] * alpha_s[5]
+    dnk2 = jnp.abs(output["dCk"][:, Nn * Nm * Np, ny, nx, nz].imag) * alpha_s[3] * alpha_s[4] * alpha_s[5]
     axes[1, 2].plot(time, dnk2, label=r'$|\delta n^{s2}_{k}|$', linestyle='-', linewidth=2.0)
     axes[1, 2].set(title='Species 2 density fluctuation', ylabel=r'$log(|\delta n^{s2}_{k}|)$', xlabel=r'$t\omega_{pe}$', yscale="log")#, ylim=[1e-20, None])
     

--- a/spectrax/_plot.py
+++ b/spectrax/_plot.py
@@ -32,13 +32,12 @@ def plot(output):
     ny = output["ny"] if Ny > 1 else 0
     nz = output["nz"] if Nz > 1 else 0
     
-    
     # Setup plots
     fig, axes = plt.subplots(2, 3, figsize=(15, 9))
     plt.subplots_adjust(hspace=0.2, wspace=0.2)
     fig.suptitle(rf'$kv_{{th,e}}/\omega_{{pe}} = {k_norm:.2},'
-                 +rf'\nu = {nu}, u_e = {u_s[0]}, \alpha_e = {alpha_s[0]:.3},'
-                 +rf'N_x = {Nx}, N_n = {Nn}, \delta n = {dn1}$', fontsize=14)
+                 +rf'\nu = {nu}, u_{{ey}} = {u_s[1]}, \alpha_e = {alpha_s[1]:.3},'
+                 +rf'N_y = {Ny}, N_n = {Nn}, \delta n = {dn1}$', fontsize=14)
     
     # Energy plots
     axes[0, 0].plot(time, output["EM_energy"], label="EM Energy")
@@ -46,63 +45,70 @@ def plot(output):
     axes[0, 0].plot(time, output["kinetic_energy_species1"], label="Kinetic Energy Species 1")
     axes[0, 0].plot(time, output["kinetic_energy_species2"], label="Kinetic Energy Species 2")
     axes[0, 0].plot(time, output["total_energy"], label="Total Energy")
-    axes[0, 0].set(title="Energy", xlabel=r"Time ($\omega_{pe}^{-1}$)", ylabel="Energy", yscale="log")#, ylim=[1e-5, None])
+    axes[0, 0].set(title="Energy", xlabel=r"Time ($\omega_{pe}^{-1}$)", ylabel="Energy", yscale="log")
     axes[0, 0].legend()
     
     # Relative Energy Error
     axes[1, 0].plot(time[1:], jnp.abs(output["total_energy"][1:]-output["total_energy"][0])/(output["total_energy"][0]+1e-9), label="Relative energy error")
-    axes[1, 0].set(xlabel=r"Time ($\omega_{pe}^{-1}$)", ylabel="Relative Energy Error", yscale="log")#, ylim=[1e-5, None])
+    axes[1, 0].set(xlabel=r"Time ($\omega_{pe}^{-1}$)", ylabel="Relative Energy Error", yscale="log")
     
     # Plot electron density fluctuation vs t.
     dnk1 = jnp.abs(output["dCk"][:, 0, ny, nx, nz].imag) * alpha_s[0] * alpha_s[1] * alpha_s[2]
     axes[1, 1].plot(time, dnk1, label=r'$|\delta n^{S1}_{k}|$', linestyle='-', linewidth=2.0)
-    axes[1, 1].set(title='Species 1 density fluctuation', ylabel=r'$log(|\delta n^{s1}_{k}|)$', xlabel=r'$t\omega_{pe}$', yscale="log")#, ylim=[1e-20, None])
+    axes[1, 1].set(title='Species 1 density fluctuation', ylabel=r'$log(|\delta n^{s1}_{k}|)$', xlabel=r'$t\omega_{pe}$', yscale="log")
     
     # Plot ion density fluctuation vs t.
     dnk2 = jnp.abs(output["dCk"][:, Nn * Nm * Np, ny, nx, nz].imag) * alpha_s[3] * alpha_s[4] * alpha_s[5]
     axes[1, 2].plot(time, dnk2, label=r'$|\delta n^{s2}_{k}|$', linestyle='-', linewidth=2.0)
-    axes[1, 2].set(title='Species 2 density fluctuation', ylabel=r'$log(|\delta n^{s2}_{k}|)$', xlabel=r'$t\omega_{pe}$', yscale="log")#, ylim=[1e-20, None])
+    axes[1, 2].set(title='Species 2 density fluctuation', ylabel=r'$log(|\delta n^{s2}_{k}|)$', xlabel=r'$t\omega_{pe}$', yscale="log")
     
     # Electron Phase space plot
-    i=0
-    vx = jnp.linspace(-4 * alpha_s[0], 4 * alpha_s[0], 201)
-    Vx, Vy, Vz = jnp.meshgrid(vx, jnp.array([0.]), jnp.array([0.]), indexing='xy')
+    i = 0
+    vy = jnp.linspace(-4 * alpha_s[1], 4 * alpha_s[1], 201)
+    Vx, Vy, Vz = jnp.meshgrid(jnp.array([0.]), vy, jnp.array([0.]), indexing='xy')
     f1 = inverse_HF_transform(Ck[:, (i*Nn*Nm*Np):(i+1)*Nn*Nm*Np, ...], Nn, Nm, Np, int(Nx), int(Ny), int(Nz),
                                   (Vx - u_s[3*i]) / alpha_s[3*i], 
                                   (Vy - u_s[3*i+1]) / alpha_s[3*i+1], 
                                   (Vz - u_s[3*i+2]) / alpha_s[3*i+2])
-    electron_phase_plot = axes[0, 1].imshow(jnp.transpose(f1[0, 0, :, 0, 0, :, 0]), extent=(0, Lx, vx[0], vx[-1]),
+    
+    # Slice explicitly to get (Ny, Nvy) -> shape (33, 201)
+    f1_2d = f1[0, :, 0, 0, :, 0, 0] 
+    
+    electron_phase_plot = axes[0, 1].imshow(jnp.transpose(f1_2d), extent=(0, Ly, vy[0], vy[-1]),
                                             cmap='jet', origin='lower', interpolation='sinc')
     plt.colorbar(electron_phase_plot, ax=axes[0, 1], label="$f_1$")
-    axes[0, 1].set(xlabel="x/d_e", ylabel="v/c", title="Species 1 Phase Space")
+    axes[0, 1].set(xlabel="y/d_e", ylabel="v_y/c", title="Species 1 Phase Space")
     axes[0, 1].set_aspect('auto', adjustable='box')
     electron_phase_text = axes[0, 1].text(
         0.5, 0.9, "", transform=axes[0, 1].transAxes, ha="center", va="top",
         fontsize=12, bbox=dict(facecolor='white', alpha=0.7, edgecolor='none'))
     
     # Ion Phase space plot
-    i=1
-    vx = jnp.linspace(-4 * alpha_s[0], 4 * alpha_s[0], 201)
-    Vx, Vy, Vz = jnp.meshgrid(vx, jnp.array([0.]), jnp.array([0.]), indexing='xy')
+    i = 1
     f2 = inverse_HF_transform(Ck[:, (i*Nn*Nm*Np):(i+1)*Nn*Nm*Np, ...], Nn, Nm, Np, int(Nx), int(Ny), int(Nz),
                                   (Vx - u_s[3*i]) / alpha_s[3*i], 
                                   (Vy - u_s[3*i+1]) / alpha_s[3*i+1], 
                                   (Vz - u_s[3*i+2]) / alpha_s[3*i+2])
-    ion_phase_plot = axes[0, 2].imshow(jnp.transpose(f2[0, 0, :, 0, 0, :, 0]), extent=(0, Lx, vx[0], vx[-1]),
+    
+    f2_2d = f2[0, :, 0, 0, :, 0, 0]
+    
+    ion_phase_plot = axes[0, 2].imshow(jnp.transpose(f2_2d), extent=(0, Ly, vy[0], vy[-1]),
                                             cmap='jet', origin='lower', interpolation='sinc')
     plt.colorbar(ion_phase_plot, ax=axes[0, 2], label="$f_2$")
-    axes[0, 2].set(xlabel="x/d_e", ylabel="v/c", title="Species 2 Phase Space")
+    axes[0, 2].set(xlabel="y/d_e", ylabel="v_y/c", title="Species 2 Phase Space")
     axes[0, 2].set_aspect('auto', adjustable='box')
     ion_phase_text = axes[0, 2].text(
         0.5, 0.9, "", transform=axes[0, 2].transAxes, ha="center", va="top",
         fontsize=12, bbox=dict(facecolor='white', alpha=0.7, edgecolor='none'))
     
     def update(frame):
-        electron_phase_plot.set_array(jnp.transpose(f1[frame, 0, :, 0, 0, :, 0]))
+        f1_2d_frame = f1[frame, :, 0, 0, :, 0, 0]
+        electron_phase_plot.set_array(jnp.transpose(f1_2d_frame))
         electron_phase_plot.set_clim(vmin=f1[frame].min(), vmax=f1[frame].max())
         electron_phase_text.set_text(f"Time: {time[frame]:.1f} * ωₚ")
         
-        ion_phase_plot.set_array(jnp.transpose(f2[frame, 0, :, 0, 0, :, 0]))
+        f2_2d_frame = f2[frame, :, 0, 0, :, 0, 0]
+        ion_phase_plot.set_array(jnp.transpose(f2_2d_frame))
         ion_phase_plot.set_clim(vmin=f2[frame].min(), vmax=f2[frame].max())
         ion_phase_text.set_text(f"Time: {time[frame]:.1f} * ωₚ")
         
@@ -114,9 +120,9 @@ def plot(output):
     dC2 = jnp.mean(jnp.abs(dCk) ** 2, axis={-3, -2, -1})
 
     plt.figure(figsize=(8, 6))
-    plt.imshow(jnp.log10(dC2[:, :Nn]), aspect='auto', cmap='viridis', 
-               interpolation='none', origin='lower', extent=(0, Nn, 0, t_max), vmin=-10, vmax=10)
-    plt.colorbar(label=r'$log_{10}(\langle |C_{1,n}|^2\rangle (t))$').ax.yaxis.label.set_size(16)
-    plt.title(r"$\langle |C_{1,n}|^2 \rangle$ vs Time and Mode Number", fontsize=16)
+    plt.imshow(jnp.log10(dC2[:, :Nm]), aspect='auto', cmap='viridis', 
+               interpolation='none', origin='lower', extent=(0, Nm, 0, t_max), vmin=-10, vmax=10)
+    plt.colorbar(label=r'$log_{10}(\langle |C_{1,m}|^2\rangle (t))$').ax.yaxis.label.set_size(16)
+    plt.title(r"$\langle |C_{1,m}|^2 \rangle$ vs Time and Mode Number", fontsize=16)
 
     plt.show()

--- a/spectrax/_simulation.py
+++ b/spectrax/_simulation.py
@@ -14,15 +14,12 @@ __all__ = ["cross_product", "ode_system", "simulation"]
 
 @partial(jit, static_argnames=['Nx', 'Ny', 'Nz'])
 def _twothirds_mask(Ny: int, Nx: int, Nz: int):
-    """Return a boolean mask in fftshifted (zero-centered) k-ordering that keeps |k|<=N//3 in each dim."""
-    def centered_modes(N):
-        # integer mode numbers in fftshift ordering: [-N//2, ..., -1, 0, 1, ..., N//2-1]
-        k = jnp.fft.fftfreq(N) * N
-        return jnp.fft.fftshift(k)
-
-    ky = centered_modes(Ny)[:, None, None]
-    kx = centered_modes(Nx)[None, :, None]
-    kz = centered_modes(Nz)[None, None, :]
+    """Return a boolean mask that keeps |k|<=N//3 in each dim."""
+    # Real-valued fft leaves only the positive-k elements on the last axis given.
+    # We choose the x-axis since this gets us the savings in 1D as well as 2D/3D.
+    ky = (jnp.fft.fftfreq(Ny) * Ny)[:, None, None]
+    kx = (jnp.fft.rfftfreq(Nx) * Nx)[None, :, None]
+    kz = (jnp.fft.fftfreq(Nz) * Nz)[None, None, :]
 
     # cutoffs (keep indices with |k| <= floor(N/3)); if N<3 this naturally keeps only k=0
     cy = Ny // 3
@@ -85,16 +82,16 @@ def ode_system(Nx, Ny, Nz, Nn, Nm, Np, Ns, t, Ck_Fk, args):
      sqrt_n_plus, sqrt_n_minus, sqrt_m_plus, sqrt_m_minus, sqrt_p_plus, sqrt_p_minus
     ) = args[7:]
 
-    total_Ck_size = Nn * Nm * Np * Ns * Nx * Ny * Nz
-    Ck = Ck_Fk[:total_Ck_size].reshape(Nn * Nm * Np * Ns, Ny, Nx, Nz)
-    Fk = Ck_Fk[total_Ck_size:].reshape(6, Ny, Nx, Nz)
+    total_Ck_size = Nn * Nm * Np * Ns * (Nx//2+1) * Ny * Nz
+    Ck = Ck_Fk[:total_Ck_size].reshape(Nn * Nm * Np * Ns, Ny, Nx//2+1, Nz)
+    Fk = Ck_Fk[total_Ck_size:].reshape(6, Ny, Nx//2+1, Nz)
 
 
     # Build the 2/3 mask once per call (JIT will constant-fold it since Nx/Ny/Nz are static)
     mask23 = _twothirds_mask(Ny, Nx, Nz)
 
-    F = jnp.fft.ifftn(jnp.fft.ifftshift(Fk * mask23, axes=(-3, -2, -1)), axes=(-3, -2, -1), norm="forward")
-    C = jnp.fft.ifftn(jnp.fft.ifftshift(Ck * mask23, axes=(-3, -2, -1)), axes=(-3, -2, -1), norm="forward")
+    F = jnp.fft.irfftn(Fk * mask23, s=(Nz, Ny, Nx), axes=(-1, -3, -2), norm="forward")
+    C = jnp.fft.irfftn(Ck * mask23, s=(Nz, Ny, Nx), axes=(-1, -3, -2), norm="forward")
 
     dCk_s_dt = Hermite_Fourier_system(Ck, C, F, kx_grid, ky_grid, kz_grid, k2_grid, col, 
                                       sqrt_n_plus, sqrt_n_minus, sqrt_m_plus, sqrt_m_minus, sqrt_p_plus, sqrt_p_minus, 
@@ -180,12 +177,12 @@ def simulation(input_parameters={}, Nx=33, Ny=1, Nz=1, Nn=20, Nm=1, Np=1, Ns=2,
         max_steps=1000000, progress_meter=TqdmProgressMeter())
         
     # Reshape the solution to extract Ck and Fk
-    Ck = sol.ys[:,:(-6 * Nx * Ny * Nz)].reshape(len(sol.ts), Ns * Nn * Nm * Np, Ny, Nx, Nz)
-    Fk = sol.ys[:,(-6 * Nx * Ny * Nz):].reshape(len(sol.ts), 6, Ny, Nx, Nz)
+    Ck = sol.ys[:,:(-6 * (Nx//2+1) * Ny * Nz)].reshape(len(sol.ts), Ns * Nn * Nm * Np, Ny, Nx//2+1, Nz)
+    Fk = sol.ys[:,(-6 * (Nx//2+1) * Ny * Nz):].reshape(len(sol.ts), 6, Ny, Nx//2+1, Nz)
     
     # Set n = 0, k = 0 mode to zero to get array with time evolution of perturbation.
-    dCk = Ck.at[:, 0, int((Ny-1)/2), int((Nx-1)/2), int((Nz-1)/2)].set(0)
-    dCk = dCk.at[:, Nn * Nm * Np, int((Ny-1)/2), int((Nx-1)/2), int((Nz-1)/2)].set(0)
+    dCk = Ck.at[:, 0, 0, 0, 0].set(0)
+    dCk = dCk.at[:, Nn * Nm * Np, 0, 0, 0].set(0)
     
     # Output results
     temporary_output = {"Ck": Ck, "Fk": Fk, "time": time, "dCk": dCk}


### PR DESCRIPTION
### Changes
- Switched all Fourier transforms from `jnp.fft.fftn` to `jnp.fft.rfftn` (and corresponding changes for inverse transforms). This computes only the k=0 and positive-k modes along the first transformed axis under the assumption that the data being transformed is real-valued, so the negative-k coefficients should be the complex conjugates of positive-k.
- Transformed along the x-axis first, so speedup applies to 1D, 2D, and 3D.
- Eliminated the shifting of Fourier coefficient arrays. Arrays are now stored as they are outputted by the RFFT function, with k=0 followed by positive k, then negative k in reverse order, instead of the previous zero-centered format.
- Specified `Nx`, `Ny`, `Nz` for all inverse transforms to maintain initial shape.
- Updated initialization of all example scripts to follow this new format. Frontend behavior only changes for the initialization of Fourier coefficients. `Nx` remains the number of spatial grid points, so parameter behavior is unchanged.
- Updated diagnostics, inverse transform, and plotting functions to work with new array shapes.
- Updated comments & docstrings to reflect changes.

### Execution time (average of 30 runs)
|                                            | Previous    | RFFT          | Improvement                |
| ----------------------------  | ----------- | ------------ | ------------------------- |
| 1D Landau damping          | 0.0287 sec | 0.0286 sec |  Negligible since Nx=3 |
| 1D Two-stream instability  | 1.11 sec     | 0.518 sec   | 2.14x faster (-53.2%)     |
| 2D Orszag-Tang                 | 12.5 sec     | 7.18 sec     | 1.74x faster (-43.4%)     |

- Benchmarked on my laptop with i7-1260P and 16 GB RAM.
- Obtained from timing each example for 30 runs in succession after an initial run to JIT compile.
- LD and TSI use parameters currently implemented in the main branch. OT uses Nn, Nm, Np = 4, Nx, Nz = 33, t_max = 100.0, otherwise same as on the main branch.